### PR TITLE
Fix "focus quotes" label

### DIFF
--- a/src/components/threads/TreeVis.tsx
+++ b/src/components/threads/TreeVis.tsx
@@ -631,7 +631,7 @@ const TreeVisContainer: React.FC<{}> = () => {
                       className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
                     />
                     <label
-                      htmlFor="moderatorMode"
+                      htmlFor="quoteMode"
                       className="ml-2 flex text-sm text-gray-900 break-words"
                     >
                       Focus Quotes


### PR DESCRIPTION
Clicked on this label on the thread viewer and it changed the wrong checkbox; this oughta fix it.